### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#paper-elements
+# paper-elements
 
 The paper elements are a set of UI components designed to implement Google's [material design](http://www.google.com/design/spec/material-design/introduction.html) guidelines.
 
@@ -6,7 +6,7 @@ The paper elements are a set of UI components designed to implement Google's [ma
 
 ### Current Priorities
 
-With the `paper-elements` we're focusing on providing the highest-quality and most resilient set of material design components on the web. We won't be publishing brand-new elements as part of the set of the time being - for more material design-based web components, see the [customelements.io](https://customelements.io/search/paper) element catalog.
+With the `paper-elements` we're focusing on providing the highest-quality and most resilient set of material design components on the web. We won't be publishing brand-new elements as part of the set of the time being - for more material design-based web components, see the [webcomponents](https://www.webcomponents.org/search/paper) element catalog.
 
 * Respond to and fix issues that come up with elements.
 * Continually performance of elements, creating "light" versions of elements where needed.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The paper elements are a set of UI components designed to implement Google's [ma
 
 ### Current Priorities
 
-With the `paper-elements` we're focusing on providing the highest-quality and most resilient set of material design components on the web. We won't be publishing brand-new elements as part of the set of the time being - for more material design-based web components, see the [webcomponents](https://www.webcomponents.org/search/paper) element catalog.
+With the `paper-elements` we're focusing on providing the highest-quality and most resilient set of material design components on the web. We won't be publishing brand-new elements as part of the set of the time being - for more material design-based web components, see the [webcomponents.org](https://www.webcomponents.org/search/paper) element catalog.
 
 * Respond to and fix issues that come up with elements.
 * Continually performance of elements, creating "light" versions of elements where needed.


### PR DESCRIPTION
[customelements.io](http://customelements.io) has been deprecated in favour of [webcomponents.org](https://webcomponents.org). This is particularly harmful since old URL currently redirects to an ad for so-called **MacKeeper**.